### PR TITLE
Fix port forwarding for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,8 +25,8 @@ Vagrant::Config.run do |config|
 
   # Forward a port from the guest to the host, which allows for outside
   # computers to access the VM, whereas host only networking does not.
-  config.vm.forward_port "http", 80, defined?(HTTP_PORT) ? HTTP_PORT : 8080
-  config.vm.forward_port "rails", 3000, defined?(RAILS_PORT) ? RAILS_PORT : 8000
+  config.vm.forward_port 80, defined?(HTTP_PORT) ? HTTP_PORT : 8080
+  config.vm.forward_port 3000, defined?(RAILS_PORT) ? RAILS_PORT : 8000
 
   # Share an additional folder to the guest VM. The first argument is
   # an identifier, the second is the path on the guest to mount the


### PR DESCRIPTION
This seems to run for the old vagrant file format, might not be useful if we are doing a complete config rewrite
